### PR TITLE
Fix macOS dependency syntax in feishin.rb

### DIFF
--- a/Casks/feishin.rb
+++ b/Casks/feishin.rb
@@ -16,7 +16,7 @@ cask "feishin" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :catalina"
+  depends_on macos: :catalina
 
   app "Feishin.app"
 


### PR DESCRIPTION
current tap syntax triggers warning in the latest version of homebrew:
``` text
Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :catalina` instead.
Please report this issue to the kgarner7/homebrew-feishin tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/kgarner7/homebrew-feishin/Casks/feishin.rb:19
```