### PR TITLE
Update macOS dependency requirement for Feishin

### DIFF
--- a/Casks/feishin.rb
+++ b/Casks/feishin.rb
@@ -16,7 +16,7 @@ cask "feishin" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :catalina"
+  depends_on macos: :catalina
 
   app "Feishin.app"
 


### PR DESCRIPTION
Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :catalina` instead. Please report this issue to the kgarner7/homebrew-feishin tap (not Homebrew/* repositories), or even better, submit a PR to fix it